### PR TITLE
chore(ci): Add cleanup step from debian-bootc-core

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -19,7 +19,6 @@ RUN git clone https://github.com/frostyard/first-setup.git --depth 1 && \
     apt-get build-dep -y . && \
     dpkg-buildpackage
 
-
 # Base Image
 FROM ghcr.io/frostyard/debian-bootc-gnome:latest
 
@@ -34,7 +33,17 @@ RUN --mount=type=bind,from=ctx,source=/,target=/ctx \
     --mount=type=cache,dst=/var/cache \
     --mount=type=cache,dst=/var/log \
     --mount=type=tmpfs,dst=/tmp \
-    /ctx/build
+    /ctx/build && \
+    rm -rf \
+        /boot \
+        /home \
+        /root \
+        /srv && \
+    mkdir /boot && \
+    mkdir /root && \
+    mkdir /home && \
+    mkdir /srv && \
+    rm -f /etc/machine-id
 
 # DEBUGGING
 # RUN apt update -y && apt install -y whois

--- a/build_files/build
+++ b/build_files/build
@@ -126,6 +126,3 @@ echo "ID_LIKE=debian" >> /usr/lib/os-release
 
 # Update build information in os-release
 sed -i "s/^BUILD_ID=.*/BUILD_ID=\"$BUILD_ID\"/" /usr/lib/os-release
-
-# Ensure first boot works
-rm -rf /etc/machine-id


### PR DESCRIPTION
Saves need to manually clean /boot when installing other kernels, probably best practice we just always do this.