### PR TITLE
fix: disable docker by default

### DIFF
--- a/system_files/usr/lib/systemd/system-preset/30-docker.preset
+++ b/system_files/usr/lib/systemd/system-preset/30-docker.preset
@@ -1,1 +1,2 @@
-enable docker.service
+disable docker.service
+disable docker.socket


### PR DESCRIPTION
Requires user to explicitly enable docker for it to start