### PR TITLE
fix: disable incus by default

### DIFF
--- a/system_files/usr/lib/systemd/system-preset/40-incus.preset
+++ b/system_files/usr/lib/systemd/system-preset/40-incus.preset
@@ -1,5 +1,5 @@
-enable incus.socket
-enable incus-user.socket
-enable incus-lxcfs.service
-enable incus-startup.service
-enable opt-incus.mount
+disable incus.socket
+disable incus-user.socket
+disable incus-lxcfs.service
+disable incus-startup.service
+disable opt-incus.mount


### PR DESCRIPTION
Requires user to explicitly enable incus for it to start